### PR TITLE
Fix require deprecated module

### DIFF
--- a/client/src/common/pymui.py
+++ b/client/src/common/pymui.py
@@ -46,7 +46,7 @@ TableCell = require('@material-ui/core/TableCell')['default']
 
 # Theming
 ThemeProvider = require('@material-ui/styles/ThemeProvider')['default']
-createMuiTheme = require('@material-ui/core/styles/createMuiTheme')['default']
+createMuiTheme = require('@material-ui/core/styles/createTheme')['default']
 useTheme = require('@material-ui/styles/useTheme')['default']
 styled = require('@material-ui/styles/styled')['default']
 makeStyles = require('@material-ui/styles/makeStyles')['default']


### PR DESCRIPTION
The module `createMuiTheme` has been renamed to `createTheme` in `material-ui` version 5, and apparently this change has been backported to version 4. When installing @material-ui as described in the book, the module is not found. Renamed to `createTheme` but only within the `require`, so that the Python side remains the same.

Found on [this SO thread](https://stackoverflow.com/questions/68911647/material-ui-cant-resolve-material-ui-core-styles-createmuitheme)